### PR TITLE
Fixing obvious things.

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_barrier.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_barrier.c
@@ -163,3 +163,5 @@ int pthread_barrier_wait( pthread_barrier_t * barrier )
 
     return iStatus;
 }
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
@@ -292,3 +292,5 @@ int pthread_cond_wait( pthread_cond_t * cond,
 {
     return pthread_cond_timedwait( cond, mutex, NULL );
 }
+
+/*-----------------------------------------------------------*/

--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_semaphore.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_semaphore.c
@@ -132,6 +132,7 @@ int sem_timedwait( sem_t * sem,
     int iStatus = 0;
     sem_internal_t * pxSem = ( sem_internal_t * ) ( sem );
     TickType_t xDelay = portMAX_DELAY;
+    int iPreviousValue = Atomic_Decrement_u32( ( uint32_t * ) &pxSem->value );
 
     if( abstime != NULL )
     {
@@ -164,8 +165,6 @@ int sem_timedwait( sem_t * sem,
             }
         }
     }
-
-    int iPreviousValue = Atomic_Decrement_u32( ( uint32_t * ) &pxSem->value );
 
     /* If previous semaphore value is larger than zero, the thread entering this function call
      * can take the semaphore without yielding. Else (<=0), calling into FreeRTOS API to yield.


### PR DESCRIPTION
As in commit message:

- Fix "warning:  #1-D: last line of file ends without a newline."
- Fix "error:  declaration may not appear after executable statement in block", when C99 is disabled.

With this PR, we are NOT trying to make code comply with C90. Given:
- The way we initialize struct, we are consistent within our own code. 
- Type casting is needed in current design. 