### PR TITLE
Remove unnecessary NULL check

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_mutex.c
@@ -148,18 +148,8 @@ int pthread_mutex_init( pthread_mutex_t * mutex,
             ( void ) xSemaphoreCreateMutexStatic( &pxMutex->xMutex );
         }
 
-        /* Ensure that the FreeRTOS mutex was successfully created. */
-        if( ( SemaphoreHandle_t ) &pxMutex->xMutex == NULL )
-        {
-            /* Failed to create mutex. Set error EAGAIN and free mutex object. */
-            iStatus = EAGAIN;
-            vPortFree( pxMutex );
-        }
-        else
-        {
-            /* Mutex successfully created. */
-            pxMutex->xIsInitialized = pdTRUE;
-        }
+        /* Mutex successfully created. */
+        pxMutex->xIsInitialized = pdTRUE;
     }
 
     return iStatus;


### PR DESCRIPTION
### Description of changes

The NULL check was unnecessary because the address of a static buffer cannot be NULL. 

It was reported here - https://github.com/FreeRTOS/Lab-Project-FreeRTOS-POSIX/issues/30



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
