### PR TITLE
pthread_cond: Use Task Notifications

### DIFF
--- a/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h
+++ b/FreeRTOS-Plus-POSIX/include/FreeRTOS_POSIX_internal.h
@@ -80,22 +80,22 @@
     typedef struct pthread_cond_internal
     {
         BaseType_t xIsInitialized;            /**< Set to pdTRUE if this condition variable is initialized, pdFALSE otherwise. */
-        StaticSemaphore_t xCondWaitSemaphore; /**< Threads block on this semaphore in pthread_cond_wait. */
-        unsigned iWaitingThreads;             /**< The number of threads currently waiting on this condition variable. */
+        TaskHandle_t* xTasksWaiting;          /**< Array of tasks awaiting the condition */
+        int tasksLenth;                       /**< Length of the xTasksWaiting Array */
     } pthread_cond_internal_t;
 
 /**
  * @brief Compile-time initializer of pthread_cond_internal_t.
  */
 
-    #define FREERTOS_POSIX_COND_INITIALIZER \
-    ( ( ( pthread_cond_internal_t )         \
-    {                                       \
-        .xIsInitialized = pdFALSE,          \
-        .xCondWaitSemaphore = { { 0 } },    \
-        .iWaitingThreads = 0                \
-    }                                       \
-        )                                   \
+    #define FREERTOS_POSIX_COND_INITIALIZER               \
+    ( ( ( pthread_cond_internal_t )                       \
+    {                                                     \
+        .xIsInitialized = pdFALSE,                        \
+        .xTasksWaiting = NULL,                            \
+        .tasksLenth = posixconfigPTHREAD_COND_MAX_WAITERS \
+    }                                                     \
+        )                                                 \
     )
 
 #endif /* if posixconfigENABLE_PTHREAD_COND_T == 1 */

--- a/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h
+++ b/FreeRTOS-Plus-POSIX/include/portable/FreeRTOS_POSIX_portable_default.h
@@ -63,6 +63,14 @@
 /**@} */
 
 /**
+ * @name Defaults for POSIX conditions implementation.
+ */
+/**@{ */
+#ifndef posixconfigPTHREAD_COND_MAX_WAITERS
+    #define posixconfigPTHREAD_COND_MAX_WAITERS 4 /**< Maximum number of tasks that can wait on a cond at one time */
+#endif
+
+/**
  * @name POSIX implementation-dependent constants usually defined in limits.h.
  *
  * They are defined here to provide portability between platforms.


### PR DESCRIPTION
Resolves #8 

*Description of changes:*
Update the pthread_cond_t implementation to utilize Task Notifications. In the existing implementation, if multiple threads of different priority are blocked on the same condition, a higher priority thread, in most cases, will unblock multiple times due to taking the underlying semaphore multiple times instead of just once. Switching to Task notifications guarantees that all tasks are equally notified and unblocked.

pthread_cond_signal has also been updated to conform to the POSIX specification in that it will unblock the highest priority task waiting on the condition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
