### PR TITLE
Remove abundant timer start in timer_settime

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
@@ -283,8 +283,7 @@ int timer_settime( timer_t timerid,
         else
         {
             /* Set the timer to expire at the it_value, then start it. */
-            ( void ) xTimerChangePeriod( xTimer, xNextTimerExpiration, portMAX_DELAY );
-            xTimerCommandSent = xTimerStart( xTimer, xNextTimerExpiration );
+            xTimerCommandSent = xTimerChangePeriod( xTimer, xNextTimerExpiration, xNextTimerExpiration );
 
             /* Wait until the timer start command is processed. */
             while( ( xTimerCommandSent != pdFAIL ) && ( xTimerIsTimerActive( xTimer ) == pdFALSE ) )


### PR DESCRIPTION
xTimerChangePeriod() can make soft timer be active. No need to call xTimerStart()

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
