### PR TITLE
timer: prevent infinate loop on one-shot timer start

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
@@ -54,7 +54,7 @@ typedef struct timer_internal
     StaticTimer_t xTimerBuffer;  /**< Memory that holds the FreeRTOS timer. */
     struct sigevent xTimerEvent; /**< What to do when this timer expires. */
     TickType_t xTimerPeriod;     /**< Period of this timer. */
-    UBaseType_t uxTimerCallbacked; /**< Number of Timer Callback times. */
+    UBaseType_t uxTimerCallbackInvocations; /**< Number of times the timer callback has been invoked. */
 } timer_internal_t;
 
 /*-----------------------------------------------------------*/
@@ -95,7 +95,7 @@ void prvTimerCallback( TimerHandle_t xTimer )
                                      pxTimer->xTimerEvent.sigev_value.sival_ptr );
         }
     }
-	pxTimer->uxTimerCallbacked++;
+    pxTimer->uxTimerCallbackInvocations++;
 }
 
 /*-----------------------------------------------------------*/
@@ -275,8 +275,8 @@ int timer_settime( timer_t timerid,
             }
         }
 
-        /* Set uxTimerCallbacked before timer start. */
-        pxTimer->uxTimerCallbacked = 0
+        /* Set uxTimerCallbackInvocations before timer start. */
+        pxTimer->uxTimerCallbackInvocations = 0
 
         /* If xNextTimerExpiration is still 0, that means that it_value specified
          * an absolute timeout in the past. Per POSIX spec, a notification should be
@@ -291,8 +291,9 @@ int timer_settime( timer_t timerid,
             xTimerCommandSent = xTimerChangePeriod( xTimer, xNextTimerExpiration, xNextTimerExpiration );
 
             /* Wait until the timer start command is processed. */
-            while( ( xTimerCommandSent != pdFAIL ) && ( xTimerIsTimerActive( xTimer ) == pdFALSE ) && \
-                   ( pxTimer->uxTimerCallbacked == 0 ) )
+            while( ( xTimerCommandSent != pdFAIL ) &&
+                   ( xTimerIsTimerActive( xTimer ) == pdFALSE ) &&
+                   ( pxTimer->uxTimerCallbackInvocations == 0 ) )
             {
                 vTaskDelay( 1 );
             }


### PR DESCRIPTION
One-shot timers that expire after a single tick could immediately transition to a dormant state, despite xTimerCommandSent being pdTRUE. This situation resulted in a potential deadlock due to an infinite loop in the timer activation process.

*Issue #, if available:*
Fix a potential dead loop issue with One-shot timers that expire after one tick. If such a timer expires immediately, its state becomes dormant while xTimerCommandSent remains pdTRUE, causing a dead loop.

*Description of changes:*
This commit adds a check to ensure the timer callback count (uxTimerCallbacked) is zero before proceeding, preventing the dead loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
