### PR TITLE
timer: add missing ";"

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_timer.c
@@ -276,7 +276,7 @@ int timer_settime( timer_t timerid,
         }
 
         /* Set uxTimerCallbackInvocations before timer start. */
-        pxTimer->uxTimerCallbackInvocations = 0
+        pxTimer->uxTimerCallbackInvocations = 0;
 
         /* If xNextTimerExpiration is still 0, that means that it_value specified
          * an absolute timeout in the past. Per POSIX spec, a notification should be


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/FreeRTOS/Lab-Project-FreeRTOS-POSIX/pull/38#issuecomment-2705835208:~:text=missing%20%3B%20in%20FreeRTOS_POSIX_timer.c%20line%20279
*Description of changes:*
I apologize for the careless error in the previous pull request. This PR fixes the missing semicolon in the code. Thanks kuopinghsu for pointing that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
