### PR TITLE
pthread_cond: refine prvInitializeStaticCond()

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread_cond.c
@@ -61,7 +61,7 @@ static bool prvInitializeStaticCond( pthread_cond_internal_t * pxCond )
     {
         /* Cond initialization must be in a critical section to prevent two threads
          * from initializing it at the same time. */
-        taskENTER_CRITICAL();
+        vTaskSuspendAll();
 
         /* Check again that the cond is still uninitialized, i.e. it wasn't
          * initialized while this function was waiting to enter the critical
@@ -82,7 +82,7 @@ static bool prvInitializeStaticCond( pthread_cond_internal_t * pxCond )
         }
 
         /* Exit the critical section. */
-        taskEXIT_CRITICAL();
+        xTaskResumeAll();
     }
 
     return pxCond->xIsInitialized;


### PR DESCRIPTION
- On v11.1 SMP, pvPortMalloc() should not be called in critical secion. vTaskSuspenAll() would trigger assert if in criticalsection.
- The pthread_cond APIs are not ISR safe. Use vTaskSuspendAll() to prevent race condition is enough.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
