### PR TITLE
Fix detach race condition

### DIFF
--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
@@ -101,10 +101,12 @@ static void prvExitThread( void )
 {
     pthread_internal_t * pxThread = ( pthread_internal_t * ) pthread_self();
 
+    vTaskSuspendAll();
     /* If this thread is joinable, wait for a call to pthread_join. */
     if( pthreadIS_JOINABLE( pxThread->xAttr.usSchedPriorityDetachState ) )
     {
         ( void ) xSemaphoreGive( ( SemaphoreHandle_t ) &pxThread->xJoinBarrier );
+        ( void ) xTaskResumeAll();
 
         /* Suspend until the call to pthread_join. The caller of pthread_join
          * will perform cleanup. */
@@ -112,6 +114,7 @@ static void prvExitThread( void )
     }
     else
     {
+        ( void ) xTaskResumeAll();
         /* For a detached thread, perform cleanup of thread object. */
         vPortFree( pxThread );
         vTaskDelete( NULL );

--- a/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
+++ b/FreeRTOS-Plus-POSIX/source/FreeRTOS_POSIX_pthread.c
@@ -102,6 +102,7 @@ static void prvExitThread( void )
     pthread_internal_t * pxThread = ( pthread_internal_t * ) pthread_self();
 
     vTaskSuspendAll();
+
     /* If this thread is joinable, wait for a call to pthread_join. */
     if( pthreadIS_JOINABLE( pxThread->xAttr.usSchedPriorityDetachState ) )
     {
@@ -362,7 +363,7 @@ int pthread_create( pthread_t * thread,
         }
 
         /* End the critical section. */
-        xTaskResumeAll();
+        ( void ) xTaskResumeAll();
     }
 
     return iStatus;
@@ -470,7 +471,7 @@ int pthread_join( pthread_t pthread,
         vPortFree( pxThread );
 
         /* End the critical section. */
-        xTaskResumeAll();
+        ( void ) xTaskResumeAll();
     }
 
     return iStatus;
@@ -529,7 +530,7 @@ int pthread_detach(pthread_t pthread)
         }
 
         /* End the critical section. */
-        xTaskResumeAll();
+        ( void ) xTaskResumeAll();
     }
 
     return iStatus;


### PR DESCRIPTION
pxThread->xAttr.usSchedPriorityDetachState may be changed by pthread_detach(). Suspend scheduler to prevent race condition.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
